### PR TITLE
Replaces the Dict based memo storage with an Array backed one

### DIFF
--- a/src/Levenshtein.elm
+++ b/src/Levenshtein.elm
@@ -7,11 +7,11 @@ module Levenshtein exposing (distance)
 -}
 
 import Array exposing (Array)
-import Memo
+import Memo as Memo
 
 
 type alias Memo =
-    Memo.Memo ( Int, Int )
+    Memo.Memo
 
 
 {-| Computes the Levenshtein distance between two strings.
@@ -59,8 +59,11 @@ helper arr1 arr2 =
 
                 _ ->
                     ( memo, max i j )
+
+        firstKey =
+            ( Array.length arr1, Array.length arr2 )
     in
-    lev Memo.empty ( Array.length arr1, Array.length arr2 )
+    lev (Memo.empty firstKey) firstKey
         |> Tuple.second
 
 

--- a/src/Memo.elm
+++ b/src/Memo.elm
@@ -1,26 +1,61 @@
 module Memo exposing (Memo, empty, fetch)
 
-import Dict exposing (Dict)
+import Array exposing (Array)
 
 
-type alias Memo comparable =
-    Dict comparable Int
+{-
+   The algorithm goes across the various combinations of characters in the two strings to be compared.
+   The result of every combination can be looked at like a grid:
+
+        -     K     I     T     T     E     N
+    - (0,0) (1,0) (2,0) (3,0) (4,0) (5,0) (6,0)
+    S (0,1) (1,1) (2,1) (3,1) (4,1) (5,1) (6,1)
+    I (0,2) (1,2) (2,2) (3,2) (4,2) (5,2) (6,2)
+    T (0,3) (1,3) (2,3) (3,3) (4,3) (5,3) (6,3)
+    T (0,4) (1,4) (2,4) (3,4) (4,4) (5,4) (6,4)
+    I (0,5) (1,5) (2,5) (3,5) (4,5) (5,5) (6,5)
+    N (0,6) (1,6) (2,6) (3,6) (4,6) (5,6) (6,6)
+    G (0,7) (1,7) (2,7) (3,7) (4,7) (5,7) (6,7)
+
+   Note that each row and column have room for one more element than the length of the string they represent.
+   To store the result for each comparison efficiently, we use a flat array, where the data looks like this:
+
+    [ (0,0), (1,0), (2,0), (3,0), (4,0), (5,0), (6,0), (0,1), (1,1), (2,1), (3,1), etc.]
+
+   Where the index to read from can be calculated from the key and the "width" of the grid.
+-}
+
+type Memo
+    = Memo Int (Array Int)
 
 
-empty : Memo comparable
-empty =
-    Dict.empty
+empty : ( Int, Int ) -> Memo
+empty ( sizeA, sizeB ) =
+    let
+        arraySize =
+            (sizeA + 1) * (sizeB + 1) - 1
+    in
+    Memo (sizeB + 1) (Array.repeat arraySize -1)
 
 
-fetch : comparable -> (Memo comparable -> comparable -> ( Memo comparable, Int )) -> Memo comparable -> ( Memo comparable, Int )
-fetch key f memo =
-    case Dict.get key memo of
+fetch : ( Int, Int ) -> (Memo -> ( Int, Int ) -> ( Memo, Int )) -> Memo -> ( Memo, Int )
+fetch (( iKey, jKey ) as key) builder ((Memo dimension store) as memo) =
+    let
+        index =
+            iKey * dimension + jKey
+    in
+    case Array.get index store of
         Just value ->
-            ( memo, value )
+            if value == -1 then
+                let
+                    ( Memo _ newStore, newValue ) =
+                        builder memo key
+                in
+                ( Memo dimension (Array.set index newValue newStore), newValue )
+
+            else
+                ( memo, value )
 
         Nothing ->
-            let
-                ( newMemo, value ) =
-                    f memo key
-            in
-            ( Dict.insert key value newMemo, value )
+            -- Would only occur if we are out of bounds on the array. This should never happen
+            ( memo, -1 )


### PR DESCRIPTION
Hey, thank you for making this library! We're using it at Humio, but we've been running into some CPU constraints on the page where we use it, and one of the things I decided to look at was to optimize the Levenshtein calculation. The benchmarks come out like this with the new and old implementation compared:

![image](https://user-images.githubusercontent.com/6695040/78351122-9b5ff700-75a6-11ea-928e-b1fe734c6201.png)

We hit a lot of worst case comparisons, so 20% improvement is something we can feel. One of the things I saw when looking at the performance of the old code, was that the backing `Dict` often had to be re-balanced when new elements were added, and the `Array` removes that concern by allocating all the space it needs up front. I also imagine the new implementation is more memory efficient, though I haven't verified that.

I hope you're up for merging it, even though it's a bit more complicated than the old implementation. Let me know if there's any blocking concerns I can remove too 🙂

Have a nice day!